### PR TITLE
Add Dotnet runtime dependency (and format)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           godotIconSVG = inputs.godot-icon-svg;
           godotManpage = inputs.godot-manpage;
           godotBin = godot;
+          dotnetPackage = pkgs.dotnetCorePackages.sdk_9_0;
         };
         default = godot-mono;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -23,25 +23,28 @@
     };
   };
 
-  outputs = {nixpkgs, ...} @ inputs: let
-    system = "x86_64-linux";
-    pkgs = nixpkgs.legacyPackages.${system};
-  in rec {
-    packages.${system} = rec {
-      godot = pkgs.callPackage ./pkgs/godot {
-        godotDesktopFile = inputs.godot-desktop-file;
-        godotIconPNG = inputs.godot-icon-png;
-        godotIconSVG = inputs.godot-icon-svg;
-        godotManpage = inputs.godot-manpage;
+  outputs =
+    { nixpkgs, ... }@inputs:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    rec {
+      packages.${system} = rec {
+        godot = pkgs.callPackage ./pkgs/godot {
+          godotDesktopFile = inputs.godot-desktop-file;
+          godotIconPNG = inputs.godot-icon-png;
+          godotIconSVG = inputs.godot-icon-svg;
+          godotManpage = inputs.godot-manpage;
+        };
+        godot-mono = pkgs.callPackage ./pkgs/godot/mono.nix {
+          godotDesktopFile = inputs.godot-desktop-file;
+          godotIconPNG = inputs.godot-icon-png;
+          godotIconSVG = inputs.godot-icon-svg;
+          godotManpage = inputs.godot-manpage;
+          godotBin = godot;
+        };
+        default = godot-mono;
       };
-      godot-mono = pkgs.callPackage ./pkgs/godot/mono.nix {
-        godotDesktopFile = inputs.godot-desktop-file;
-        godotIconPNG = inputs.godot-icon-png;
-        godotIconSVG = inputs.godot-icon-svg;
-        godotManpage = inputs.godot-manpage;
-        godotBin = godot;
-      };
-      default = godot-mono;
     };
-  };
 }

--- a/pkgs/godot/mono.nix
+++ b/pkgs/godot/mono.nix
@@ -48,10 +48,14 @@ godotBin.overrideAttrs (
     installPhase = ''
       mkdir -p $out/bin $out/opt/godot-mono
 
+
       install -m 0755 source/${godotName} $out/opt/godot-mono/${godotName}
       cp -r source/GodotSharp $out/opt/godot-mono
 
       ln -s $out/opt/godot-mono/${godotName} $out/bin/godot-mono
+
+      # Ensure that the dotnet package survives garbage collection
+      echo "${dotnetPackage}" >> $out/bin/runtime-deps.txt
 
       # Only create a desktop file, if the necessary variables are set
       # these are set only, if one installs this program using flakes.

--- a/pkgs/godot/mono.nix
+++ b/pkgs/godot/mono.nix
@@ -8,6 +8,7 @@
   godotIconPNG,
   godotIconSVG,
   godotManpage,
+  dotnetPackage,
   version ? "4.3-stable",
   versionHash ? "sha256-7N881aYASmVowZlYHVi6aFqZBZJuUWd5BrdvvdnK01E=",
   arch ? "linux.x86_64",
@@ -30,6 +31,7 @@ godotBin.overrideAttrs (
     buildInputs = oldAttrs.buildInputs ++ [
       zlib
       msbuild
+      dotnetPackage
     ];
 
     libraries = lib.makeLibraryPath buildInputs;

--- a/pkgs/godot/mono.nix
+++ b/pkgs/godot/mono.nix
@@ -13,60 +13,62 @@
   arch ? "linux.x86_64",
   archWithUnderscore ? "linux_x86_64", # I have no comment on that..
 }:
-godotBin.overrideAttrs (oldAttrs: let
-  godotName = "Godot_v${version}_mono_${arch}";
-  godotNameUnderscore = "Godot_v${version}_mono_${archWithUnderscore}";
-in rec {
-  pname = "godot-mono";
+godotBin.overrideAttrs (
+  oldAttrs:
+  let
+    godotName = "Godot_v${version}_mono_${arch}";
+    godotNameUnderscore = "Godot_v${version}_mono_${archWithUnderscore}";
+  in
+  rec {
+    pname = "godot-mono";
 
-  src = fetchurl {
-    url = "https://github.com/godotengine/godot-builds/releases/download/${version}/Godot_v${version}_mono_${archWithUnderscore}.zip";
-    sha256 = versionHash;
-  };
+    src = fetchurl {
+      url = "https://github.com/godotengine/godot-builds/releases/download/${version}/Godot_v${version}_mono_${archWithUnderscore}.zip";
+      sha256 = versionHash;
+    };
 
-  buildInputs =
-    oldAttrs.buildInputs
-    ++ [
+    buildInputs = oldAttrs.buildInputs ++ [
       zlib
       msbuild
     ];
 
-  libraries = lib.makeLibraryPath buildInputs;
+    libraries = lib.makeLibraryPath buildInputs;
 
-  #Godot_v4.3-stable_mono_linux.x86_64
-  #Godot_v4.3-stable_mono_linux.x86_64
-  unpackPhase = ''
-    mkdir source
-    unzip $src -d source
-    mv source/${godotNameUnderscore}/* source
-    rmdir source/${godotNameUnderscore}
+    #Godot_v4.3-stable_mono_linux.x86_64
+    #Godot_v4.3-stable_mono_linux.x86_64
+    unpackPhase = ''
+      mkdir source
+      unzip $src -d source
+      mv source/${godotNameUnderscore}/* source
+      rmdir source/${godotNameUnderscore}
 
-  '';
-  installPhase = ''
-    mkdir -p $out/bin $out/opt/godot-mono
+    '';
+    installPhase = ''
+      mkdir -p $out/bin $out/opt/godot-mono
 
-    install -m 0755 source/${godotName} $out/opt/godot-mono/${godotName}
-    cp -r source/GodotSharp $out/opt/godot-mono
+      install -m 0755 source/${godotName} $out/opt/godot-mono/${godotName}
+      cp -r source/GodotSharp $out/opt/godot-mono
 
-    ln -s $out/opt/godot-mono/${godotName} $out/bin/godot-mono
+      ln -s $out/opt/godot-mono/${godotName} $out/bin/godot-mono
 
-    # Only create a desktop file, if the necessary variables are set
-    # these are set only, if one installs this program using flakes.
-    if [[ -f "${godotDesktopFile}" ]]; then
-      mkdir -p "$out/man/share/man/man6"
-      cp ${godotManpage} "$out/man/share/man/man6/"
+      # Only create a desktop file, if the necessary variables are set
+      # these are set only, if one installs this program using flakes.
+      if [[ -f "${godotDesktopFile}" ]]; then
+        mkdir -p "$out/man/share/man/man6"
+        cp ${godotManpage} "$out/man/share/man/man6/"
 
-      mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
-      cp ${godotDesktopFile} "$out/share/applications/org.godotengine.Godot-Mono.desktop"
-      cp ${godotIconSVG} "$out/share/icons/hicolor/scalable/apps/godot.svg"
-      cp ${godotIconPNG} "$out/share/icons/godot.png"
-      substituteInPlace "$out/share/applications/org.godotengine.Godot-Mono.desktop" \
-        --replace "Exec=godot" "Exec=$out/bin/godot-mono"
-    fi
-  '';
+        mkdir -p $out/share/{applications,icons/hicolor/scalable/apps}
+        cp ${godotDesktopFile} "$out/share/applications/org.godotengine.Godot-Mono.desktop"
+        cp ${godotIconSVG} "$out/share/icons/hicolor/scalable/apps/godot.svg"
+        cp ${godotIconPNG} "$out/share/icons/godot.png"
+        substituteInPlace "$out/share/applications/org.godotengine.Godot-Mono.desktop" \
+          --replace "Exec=godot" "Exec=$out/bin/godot-mono"
+      fi
+    '';
 
-  postFixup = ''
-    wrapProgram $out/bin/godot-mono \
-      --set LD_LIBRARY_PATH ${libraries}
-  '';
-})
+    postFixup = ''
+      wrapProgram $out/bin/godot-mono \
+        --set LD_LIBRARY_PATH ${libraries}
+    '';
+  }
+)


### PR DESCRIPTION
Hi there!

As Godot 4 Mono will not work properly without at least the dotnet 6 runtime present (it outputs an error message and will not properly build C# code), I've added a runtime dependency to the dotnet 9 nix package as it's currently the most up-to-date version in nixpkgs. 

I also used nixfmt to make it easier for me to grok the code, so the actual material changes (about four significant lines) are in the second and third commits.